### PR TITLE
feat: add new line for consecutive incert uses

### DIFF
--- a/main.go
+++ b/main.go
@@ -180,7 +180,7 @@ func newImage(old v1.Image, caCertBytes []byte) (v1.Image, error) {
 		if err != nil {
 			log.Fatalf("Failed to extract CA certificates from image: %s\n", err)
 		}
-		newCaCertBytes = append(imgCaCertBytes, caCertBytes...)
+		newCaCertBytes = append(append(imgCaCertBytes, caCertBytes...), '\n')
 	}
 
 	// Create a new tar file with the modified ca-certificates file


### PR DESCRIPTION
Hello, great tool!

When I need to use _incert_ consecutive times in the same image, the `ca-certificates.crt` file gets unformatted.

Expected behavior:
```
-----BEGIN CERTIFICATE-----
ABC1
-----END CERTIFICATE-----
-----BEGIN CERTIFICATE-----
ABC2
-----END CERTIFICATE-----
-----BEGIN CERTIFICATE-----
ABC3
-----END CERTIFICATE-----
```

Actual behavior:
```
-----BEGIN CERTIFICATE-----
ABC1
-----END CERTIFICATE----------BEGIN CERTIFICATE-----
ABC2
-----END CERTIFICATE----------BEGIN CERTIFICATE-----
ABC3
-----END CERTIFICATE-----
```

This pr aims to add a new line after appending the certificate (in order to achieve the expected behavior).