### PR TITLE
Add support for multi-arch images

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,18 @@ Ti07NEPhmg4NpGaXutIcSkwsKouLgU9xGqndXHt7CMUADTdA43x7VF8vhV929ven
 sBxXVsFy6K2ir40zSbofitzmdHxghm+Hl3s=
 -----END CERTIFICATE-----
 ```
+
+## Multi-Architecture Images
+
+When `incert` encounters a reference to an [image
+index](https://specs.opencontainers.org/image-spec/image-index/) it will insert
+certificates into each image in the index and publish a new index to the
+destination.
+
+If you provide the `-platform` flag, it will resolve the index to the manifest
+for that platform and publish an updated manifest to the destination.
+
+If you provide a platform that isn't in the index, it will return an error.
+
+The `-platform` flag will be ignored when the `-image-url` refers to a
+[manifest](https://specs.opencontainers.org/image-spec/manifest/).

--- a/test/test.sh
+++ b/test/test.sh
@@ -4,7 +4,7 @@
 # Assumes incert is at "../incert" and docker is available
 
 set -e
-#set -x
+set -x
 
 cleanup() { 
   docker rm -f $NGINX
@@ -29,12 +29,25 @@ NGINX=$(docker run -p 8443:8443 -d \
 # check insecure curl works
 docker run --rm -it --network host --add-host example.com:127.0.0.1 cgr.dev/chainguard/curl:latest-dev -k https://example.com:8443
 
-# now create container with cert and try
+# now create container with cert and try; this should produce an image index
 IMAGE=ttl.sh/incert/test-default-$RANDOM:20m
 ../incert --ca-certs-file selfsigned.pem --image-url cgr.dev/chainguard/curl:latest --dest-image-url $IMAGE
 docker run --rm -it --network host --add-host example.com:127.0.0.1 $IMAGE https://example.com:8443
+docker manifest inspect $IMAGE | docker run --rm -i --entrypoint jq cgr.dev/chainguard/curl:latest-dev -e '.mediaType == "application/vnd.oci.image.index.v1+json"'
 
-# test using platform argument
+# test using platform argument; this should produce an image manifest
 IMAGE=ttl.sh/incert/test-arm64-default-$RANDOM:20m
 ../incert --ca-certs-file selfsigned.pem --image-url cgr.dev/chainguard/curl:latest --platform linux/arm64 --dest-image-url $IMAGE
+docker run --rm -it --network host --add-host example.com:127.0.0.1 $IMAGE https://example.com:8443
+docker manifest inspect $IMAGE | docker run --rm -i --entrypoint jq cgr.dev/chainguard/curl:latest-dev -e '.mediaType == "application/vnd.oci.image.manifest.v1+json"'
+
+# test against a specific manifest, rather than an index
+IMAGE=ttl.sh/incert/test-image-$RANDOM:20m
+CURL_DIGEST=$(docker manifest inspect cgr.dev/chainguard/curl:latest | docker run --rm -i --entrypoint jq cgr.dev/chainguard/curl:latest-dev -r '.manifests[] | select(.platform.architecture == "arm64" and .platform.os == "linux") | .digest')
+../incert --ca-certs-file selfsigned.pem --image-url cgr.dev/chainguard/curl@$CURL_DIGEST --dest-image-url $IMAGE
+docker run --rm -it --network host --add-host example.com:127.0.0.1 $IMAGE https://example.com:8443
+
+# for manifests, the --platform flag should make no difference
+IMAGE=ttl.sh/incert/test-image-amd64-$RANDOM:20m
+../incert --ca-certs-file selfsigned.pem --image-url cgr.dev/chainguard/curl@$CURL_DIGEST --platform=linux/amd64 --dest-image-url $IMAGE
 docker run --rm -it --network host --add-host example.com:127.0.0.1 $IMAGE https://example.com:8443

--- a/test/test.sh
+++ b/test/test.sh
@@ -41,6 +41,13 @@ IMAGE=ttl.sh/incert/test-arm64-default-$RANDOM:20m
 docker run --rm -it --network host --add-host example.com:127.0.0.1 $IMAGE https://example.com:8443
 docker manifest inspect $IMAGE | docker run --rm -i --entrypoint jq cgr.dev/chainguard/curl:latest-dev -e '.mediaType == "application/vnd.oci.image.manifest.v1+json"'
 
+# test specifying a platform that doesn't exist in the index; this should
+# produce an error
+IMAGE=ttl.sh/incert/test-386-$RANDOM:20m
+../incert --ca-certs-file selfsigned.pem --image-url cgr.dev/chainguard/curl:latest --platform linux/386 --dest-image-url $IMAGE \
+  && (echo "Unexpected exit status for missing platform: 0"; exit 1) \
+  || true
+
 # test against a specific manifest, rather than an index
 IMAGE=ttl.sh/incert/test-image-$RANDOM:20m
 CURL_DIGEST=$(docker manifest inspect cgr.dev/chainguard/curl:latest | docker run --rm -i --entrypoint jq cgr.dev/chainguard/curl:latest-dev -r '.manifests[] | select(.platform.architecture == "arm64" and .platform.os == "linux") | .digest')


### PR DESCRIPTION
Presently, when `incert` encounters a multi-arch image it will resolve it down to the platform specific manifest (by default linux/amd64) and insert certificates into that. A single manifest is published to the destination.

With this change, `incert` will insert the certificates into each image in the list and publish a new index to the destination, derived from the source.

I think this matches the user's expectation of how the command would behave and removes some toil for users who are interested in actually consuming multiple architectures.

This changes the default behaviour of `incert` when it encounters a multi-arch image and could be considered a breaking change.

The alternative would be to put this behind a `--recursive` flag or something but my feeling is that this is the expected default behaviour.