### PR TITLE
fix(ci): disable the Go cache in the signed-release flow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,10 @@ jobs:
         with:
           go-version-file: './go.mod'
           check-latest: true
+          # Don't restore the Go module/build cache in the signed-release flow:
+          # the Go build cache is trusted by input-hash (not go.sum-verified), so
+          # a cache poisoned by a less-trusted run could contaminate the release.
+          cache: false
 
       - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:


### PR DESCRIPTION
Follow-up to the GitHub Actions hardening in #104. Workflow-config only — no
application code is touched.

`release.yaml`'s `actions/setup-go` enables the Go module + build cache by
default. The Go **build** cache stores compiled objects keyed by an input hash
and is reused on a cache hit without being re-verified against source — `go.sum`
covers module *downloads*, not the build cache. So a cache poisoned by a
less-trusted run (e.g. the `pull_request`-triggered `build-snapshot` job, which
shares the same `go.sum`-derived cache key) could be restored into the signed
release build and contaminate published artifacts.

This sets `cache: false` on the release job's `setup-go` step, so the signed
release compiles from clean, checksum-verified module downloads and consumes no
PR-writable cache.

Refs: PSEC-923